### PR TITLE
Changes to the requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-json
-os
-re
-time
-uuid
-calendar
-datetime
 feedparser
 openai
 pytz


### PR DESCRIPTION
- The libraries removed were: json, os, re, time, uuid, calendar, and datetime, as they are all standard Python libraries and do not need to be specified in the requirements.txt file;

- File name requirements.txt had a special character in front.